### PR TITLE
Add ability to stash and rebase in addition to merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,19 @@ packages/documentation/copy/es/**/*.ts @KingDarBoja [translate] [es]
 
 ## Config
 
-There is only one option available ATM, `cwd` which can be used to determine the root folder to look for CODEOWNER files in:
+There are only two options available at the moment:
+
+- `cwd`, which can be used to determine the root folder to look for CODEOWNER files in.
+- `merge_method`, which can be `merge` (default), `squash` or `rebase`, depending on what you want the action to do.
 
 ```yml
 - name: Run Codeowners merge check
   uses: OSS-Docs-Tools/code-owner-self-merge@v1
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  with: 
+  with:
     cwd: './docs'
+    merge_method: 'squash'
 ```
 
 ### Dev

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   cwd:
     description: 'The path to the root folder where it should look for code owners'
     default: ''
+  merge_method:
+    description: "The merge strategy to use: 'merge', 'squash' or 'rebase'"
+    default: 'merge'
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -139,7 +139,8 @@ async function mergeIfLGTMAndHasAccess() {
 
   core.info(`Creating comments and merging`)
   try {
-    await octokit.pulls.merge({ ...thisRepo, pull_number: issue.number });
+    // @ts-ignore
+    await octokit.pulls.merge({ ...thisRepo, pull_number: issue.number, merge_method: core.getInput('merge_method') || 'merge' });
     await octokit.issues.createComment({ ...thisRepo, issue_number: issue.number, body: `Merging because @${sender} is a code-owner of all the changes - thanks!` });
   } catch (error) {
     await octokit.issues.createComment({ ...thisRepo, issue_number: issue.number, body: `There was an issue merging, maybe try again ${sender}.` });


### PR DESCRIPTION
This PR allows for merging using squash and rebase.

### Why?

Some repos (mine including) have disabled the default merge strategy and instead squash all pull requests.
This action silently fails with
```
Looking at PR: [my PR name]
(node:1497) UnhandledPromiseRejectionWarning: HttpError: Merge commits are not allowed on this repository.
```

EDIT:
On version 1.5.1, it commented on the PR

> There was an issue merging, maybe try again diogotcorreia.

### Other information

~~I don't really know how to test GitHub Actions, so I haven't tested it.~~ Just tested it, it works perfectly.

Also, TypeScript was complaining about the conversion from `string` to `'merge' | 'squash' | 'rebase'`. I also don't really know how to fix that, so I added `// @ts-ignore`.

Feel free to request changes if needed.