### PR TITLE
Fix green status check always failing when it has statuses

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,12 @@ async function mergeIfLGTMAndHasAccess() {
 
   // Don't merge red PRs
   const statusInfo = await octokit.repos.listCommitStatusesForRef({ ...thisRepo, ref: prInfo.data.head.sha })
-  const failedStatus = statusInfo.data.find(s => s.state !== "success")
+  const failedStatus = statusInfo.data
+    .filter(
+      (thing, index, self) =>
+        index === self.findIndex((t) => t.target_url === thing.target_url)
+    )
+    .find(s => s.state !== "success")
 
   if (failedStatus) {
     await octokit.issues.createComment({ ...thisRepo, issue_number: issue.number, body: `Sorry @${sender}, this PR could not be merged because it wasn't green. Blocked by [${failedStatus.context}](${failedStatus.target_url}): '${failedStatus.description}'.` });

--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ async function mergeIfLGTMAndHasAccess() {
   // Don't merge red PRs
   const statusInfo = await octokit.repos.listCommitStatusesForRef({ ...thisRepo, ref: prInfo.data.head.sha })
   const failedStatus = statusInfo.data
+    // Check only the most recent for a set of duplicated statuses
     .filter(
       (thing, index, self) =>
         index === self.findIndex((t) => t.target_url === thing.target_url)


### PR DESCRIPTION
When there is a deployment/code checking/etc, the GitHub API returns an array with the timeline. That means, even if a status has state `success` now, there is still an object in the array that has the state `pending`.

As an example, take a look at [this API response](https://api.github.com/repos/diogotcorreia/resumos-leic/statuses/f41efdc8e6a41234ebb7aeee6cd93fce4ee8697d) from [this PR](https://github.com/diogotcorreia/resumos-leic/pull/89).

This PR adds a filter to the array that removes duplicate statuses, keeping only the last ones (e.g. the ones at the beginning of the array). JSON objects are compared by the `target_url` property since that's unique and is the only thing that doesn't change between the status update.

This has been tested in the PR linked above.