### PR TITLE
Actions URI has changed. Update to use correct URI.

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ class Actor {
       core.error(error)
       core.setFailed("Failed to merge")
 
-      const linkToCI = `https://github.com/${thisRepo.owner}/${thisRepo.repo}/runs/${process.env.GITHUB_RUN_ID}?check_suite_focus=true`
+      const linkToCI = `https://github.com/${thisRepo.owner}/${thisRepo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}?check_suite_focus=true`
       await octokit.issues.createComment({ ...thisRepo, issue_number: issue.number, body: `There was an issue merging, maybe try again ${sender}. <a href="${linkToCI}">Details</a>` });
     }
   }


### PR DESCRIPTION
When the action runs, if it fails, it adds a comment like this:

<img width="952" alt="Screenshot 2022-09-18 at 17 25 57" src="https://user-images.githubusercontent.com/10003354/190917599-e63b67c3-d58a-4fed-ad95-a5fbc4c05825.png">

GitHub have slightly changed their URI since this was originally implemented.

This PR fixes the URI to match GitHub's new structure.
