### PR TITLE
Update version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A GitHub action that lets code-owners merge PRs via a comment.
 
-This action uses the standardized structure of [a CODEOWNERS file](https://github.blog/2017-07-06-introducing-code-owners/) to handle the access controls. 
+This action uses the standardized structure of [a CODEOWNERS file](https://github.blog/2017-07-06-introducing-code-owners/) to handle the access controls.
 
 <img src="screenshots/img.png">
 
@@ -126,4 +126,4 @@ Use `npx jest --watch` to run tests.
 
 ### Deploy
 
-Use the GH UI to make a tag and release
+Use the GH UI to make a tag and release.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const {readFileSync} = require("fs");
 
 // Effectively the main function
 async function run() {
-  core.info("Running version 1.6.0")
+  core.info("Running version 1.6.5")
 
   // Tell folks they can merge
   if (context.eventName === "pull_request_target") {


### PR DESCRIPTION
We use `code-owner-self-merge` at [SchemaStore](https://github.com/SchemaStore/schemastore) and I noticed that the version string is confusingly out of date.

I fixed some typos along the way, but did not update the documentation to add a note to remember to do this.