### PR TITLE
Add `ownerNoPings` option to prevent GitHub pings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ packages/documentation/copy/es/**/*.ts @KingDarBoja [translate] [es]
 
 ## Config
 
-There are five options available at the moment:
+There are six options available at the moment:
 
 - `cwd`, which can be used to determine the root folder to look for CODEOWNER files in.
 - `merge_method`, which can be `merge` (default), `squash` or `rebase`, depending on what you want the action to do.
 - `quiet` - does not output a message saying who can merge PRs
+- `ownerNoPings` - list of usernames to wrap mention in an inline code block to prevent pinging
 
 ```yml
 - name: Run Codeowners merge check

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ inputs:
     default: ''
     required: false
 
+  ownerNoPings:
+    description: 'Wrap mention in inline code block to prevent pings'
+    default: '[]'
+    required: false
+
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ async function commentOnMergablePRs() {
     process.exit(0)
   }
 
-  
+
 
 
   // Determine who has access to merge every file in this PR
@@ -94,7 +94,11 @@ async function commentOnMergablePRs() {
     process.exit(0)
   }
 
-  const owners = new Intl.ListFormat().format(ownersWhoHaveAccessToAllFilesInPR);
+  const ownerNoPings = JSON.parse(core.getInput('ownerNoPings'))
+  const formattedOwnersWhoHaveAccessToAllFilesInPR = ownersWhoHaveAccessToAllFilesInPR.map((owner) => {
+    return ownerNoPings.includes(owner) ? `\`${owner}\`` : owner
+  })
+  const owners = new Intl.ListFormat().format(formattedOwnersWhoHaveAccessToAllFilesInPR);
   const message = `Thanks for the PR!
 
 This section of the codebase is owned by ${owners} - if they write a comment saying "LGTM" then it will be merged.


### PR DESCRIPTION
This closes #42, adding a `ownerNoPings` option to prevent pinging certain people.

This codepath has been tested at [schemastore](https://github.com/SchemaStore/schemastore) since [this MR](https://github.com/SchemaStore/schemastore/pull/3592).