### PR TITLE
ci: Update actions and set minimal Node.js version to v14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14'
       - run: yarn install
       - run: npx jest


### PR DESCRIPTION
In [CI](https://github.com/OSS-Docs-Tools/code-owner-self-merge/actions/runs/8429896934/job/23084878895), `npx jest` fails:

```console
$ npx jest
npx: installed 285 in 11.833s
Unexpected token .
```

This is because `actions/setup-node@v1` uses Node.js v10 by default:

```console
$ mise exec node@10 -- npx jest
npx: installed 285 in 15.951s
Unexpected token .
```

However, tests pass with a minimal Node.js version of v14:

```console
$ mise exec node@14 -- npx jest
npx: installed 285 in 8.205s
PASS  ./index.test.js
  ✓ determine who owns a set of files (13 ms)
  ✓ real world (2 ms)
  ✓ real world 2 (2 ms)
  ✓ real world with labels (2 ms)
  ✓ deciding if someone has access to merge (5 ms)
  githubLoginIsInCodeowners
    ✓ allows folks found in the codeowners (1 ms)
    ✓ ignores case (1 ms)
    ✓ denies other accounts (2 ms)
    ✓ denies subsets of existing accounts (1 ms)

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        0.738 s, estimated 1 s
Ran all test suites.
```

This PR updates the actions and sets v14 as the default Node.js version installed. Both v14 and v16 are both EOL, so naturally the major version could be bumped if it is not constrained by compatibility concerns.