### PR TITLE
Do not throw error on empty approved review

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,14 @@ function pathListToMarkdown(files) {
 }
 
 function getPayloadBody() {
-  const body = context.payload.comment ? context.payload.comment.body : context.payload.review.body
+  let body = context.payload.comment ? context.payload.comment.body : context.payload.review.body
+  /**
+   * Of the three ways to review code ("commented", "approved", "changes_requested"), only
+   * "approved" can have a "null" body. For that case, ignore instead of throw error.
+   */
+  if (context.payload?.review?.state === 'approved' && body === null) {
+    body = ''
+  }
   if (body == null) {
     throw new Error(`No body found, ${JSON.stringify(context)}`)
   }


### PR DESCRIPTION
Hello Again!

When performing a GitHub code review, approving the PR with an no typed body would throw an error (would look something like [this](https://github.com/SchemaStore/schemastore/actions/runs/13363170953/job/37316156649).

As noted in the code comments, when doing a GitHub review, it is possible to request changes, only comment, or approve. The GitHub web UI only allows successfully sending a review with no body if the PR is "approved".

This fixes that case so no error is thrown. I've tested it [here](https://github.com/SchemaStore/schemastore/pull/4447) and it seems to work