### PR TITLE
Do not throw error on review comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,12 @@ function getPayloadBody() {
   if (context.payload?.review?.state === 'approved' && body === null) {
     body = ''
   }
+  /**
+   * Comments on pull request reviews have a "null" body.
+   */
+  if (context.payload?.review?.state === 'commented' && body === null) {
+    body = ''
+  }
   if (body == null) {
     throw new Error(`No body found, ${JSON.stringify(context)}`)
   }


### PR DESCRIPTION
When adding comments under a review, the action would previously throw an error due to a `null` body.

Tried looking for the body, but as mentioned in #35, the body of pull request review comments doesn't seem to be documented. The event payload seems to have a `review` property, but it seems to be associated with the overall review rather than a particular review comment.

```json5
review: {
    _links: { html: [Object], pull_request: [Object] },
    author_association: 'MEMBER',
    body: null,
    commit_id: '58e4709c661af8de19e52af500d6808ff0a0504f',
    html_url: 'https://github.com/SchemaStore/schemastore/pull/4587#pullrequestreview-2705553345',
    id: 2705553345,
    node_id: 'PRR_kwDOAZi2O86hQ3fB',
    pull_request_url: 'https://api.github.com/repos/SchemaStore/schemastore/pulls/4587',
    state: 'commented',
    submitted_at: '2025-03-21T11:09:40Z',
    user: {
```

If one truly needed this feature, somebody could iterate through `pulls.listReviewComments` for the current PR, and compare it's `update_at` property with the current review comment's `submitted_at` property. Although, of course it would lead to bad results if two people comment within the same second. Property values may also be unexpected when updating comments.

For now, simply set `body` so that no crashes occur.