### PR TITLE
Update docs to broaden event types in `pull_request_target`

### DIFF
--- a/.github/workflows/code-owners-merge.yml
+++ b/.github/workflows/code-owners-merge.yml
@@ -1,6 +1,6 @@
 name: Codeowners merging
 on:
-  pull_request_target: { types: opened }
+  pull_request_target: { types: [opened, reopened, ready_for_review] }
   issue_comment: { types: created }
   pull_request_review: { types: submitted }
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You want a unique workflow file, e.g. `.github/workflows/codeowners-merge.yml`
 ```yml
 name: Codeowners merging
 on:
-  pull_request_target: { types: [opened] }
+  pull_request_target: { types: [opened, reopened, ready_for_review] }
   issue_comment: { types: [created] }
   pull_request_review: { types: [submitted] }
 


### PR DESCRIPTION
At SchemaStore, we made [these](https://github.com/SchemaStore/schemastore/pull/5572) changes due to a bug where a draft pull request, when marked as "ready for review", wouldn't run the Codeowner merge bot. I also added "reopened" for similar reasons.